### PR TITLE
Fixes #1 and #2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gatsby-mdx-remote",
-  "version": "1.0.12",
+  "version": "1.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gatsby-mdx-remote",
-      "version": "1.0.12",
+      "version": "1.0.16",
       "license": "MIT",
       "dependencies": {
         "gatsby-source-filesystem": "^5.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-mdx-remote",
-  "version": "1.0.13",
+  "version": "1.0.16",
   "description": "A plugin to transform nodes with mdx content and frontmatter into mdx File nodes for consumption by the gatsby-plugin-mdx plugin",
   "main": "index.js",
   "homepage": "https://github.com/dfrnt-com/gatsby-mdx-remote#readme",

--- a/src/createMdxNode.ts
+++ b/src/createMdxNode.ts
@@ -107,6 +107,6 @@ function getMdxFrontmatter(typeConfig: PluginTypeOptions, nodeData: Node & Recor
   const frontmatterFields = (frontmatterField && (frontmatterField.indexOf(".") !== -1 ? frontmatterField.split(".") : [frontmatterField])) || undefined;
   const recursedFrontmatterFieldData = frontmatterFields && recurseFieldContent(nodeData, frontmatterFields);
   const frontmatterFieldData = (recursedFrontmatterFieldData && typeof recursedFrontmatterFieldData !== "string" && recursedFrontmatterFieldData) || undefined;
-  const frontmatter = frontmatterFieldData && `---\n${YAML.stringify({ ...frontmatterFieldData, imageList: urlList })}---\n`;
+  const frontmatter = frontmatterFieldData && `---\n${YAML.stringify({ ...frontmatterFieldData, markdownImageList: urlList })}---\n`;
   return frontmatter;
 }

--- a/src/extractUrlAndReplaceWithGatsbyImage.ts
+++ b/src/extractUrlAndReplaceWithGatsbyImage.ts
@@ -31,7 +31,7 @@ export const extractUrlAndReplaceWithGatsbyImage =
         const index = options.getUrlListLength();
         options.pushImageUrlToList(node.url);
         const providedClassName = options.className ? `className="${options.className}"` : "";
-        const html = `<GatsbyImage alt="${node.alt}" title="${node.title}" image={getImage(props.pageContext.images[${index}]?.childImageSharp?.gatsbyImageData)} ${providedClassName} />\n`;
+        const html = `<GatsbyImage alt="${node.alt}" title="${node.title}" image={getImage(props.pageContext.markdownImageList[${index}]?.childImageSharp?.gatsbyImageData)} ${providedClassName} />\n`;
         node.type = "html";
         node.name = "GatsbyImage";
         node.children = undefined;


### PR DESCRIPTION
Added frontmatter from markdownImages automatically:
* markdownImageList (virtual section)
* customizable field for an image array to preprocess

Added support for childMdx under mdxMyTypeName to ensure rich content nodes can be queries and support MDX.